### PR TITLE
Add scm and developers sections in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,20 @@
         </license>
     </licenses>
 
+    <scm>
+        <connection>scm:git:git://github.com/awslabs/dqdl.git</connection>
+        <developerConnection>scm:git:ssh://github.com:awslabs/dqdl.git</developerConnection>
+        <url>https://github.com/awslabs/dqdl/tree/main</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <id>rdsharma26</id>
+            <name>Rahul Sharma</name>
+            <url>https://github.com/rdsharma26</url>
+        </developer>
+    </developers>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
Add scm and developers sections to publish to maven, resolving the following error:

```
[ERROR] Repository "softwareamazonglue-1007" failures
[ERROR]   Rule "pom-staging" failures
[ERROR]     * Invalid POM: /software/amazon/glue/dqdl/0.9.0/dqdl-0.9.0.pom: SCM URL missing, Developer information missing
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
