### PR TITLE
Fix bump-version PR to target the branch it was published from

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,7 +173,7 @@ jobs:
           git push origin "${BRANCH_NAME}"
 
           gh pr create \
-            --base master \
+            --base ${{ github.ref_name }} \
             --head "${BRANCH_NAME}" \
             --title "Update version in pom.xml to ${NEXT_VERSION}" \
             --body "Automated version bump after publishing ${RELEASE_VERSION} to Maven Central."


### PR DESCRIPTION
*Issue #, if available:*
PR #26 

*Description of changes:*
The bump-version job in the publish workflow was hardcoded to create PRs targeting `master`. When publishing from a release branch (e.g., `release/dqdl-1.0.4`), the version bump PR should target that release branch instead.                                                                                             
                                                                                                                                                                                                                                                                                                                            
Changed `--base master` to `--base ${{ github.ref_name }}` so the PR targets whichever branch the publish was triggered from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
