### PR TITLE
Update secrets-scan.yml

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,23 +1,19 @@
-name: TruffleHog Secrets Scan
+  on:
+    push:
+      branches: [ "master" ]
+    pull_request:
+      branches: [ "master" ]
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-
-jobs:
-  secrets-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --debug --only-verified
+  jobs:
+    secrets-scan:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: TruffleHog OSS
+          uses: trufflesecurity/trufflehog@main
+          with:
+            path: ./
+            extra_args: --debug --only-verified

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,19 +1,19 @@
-  on:
-    push:
-      branches: [ "master" ]
-    pull_request:
-      branches: [ "master" ]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
-  jobs:
-    secrets-scan:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
-        - name: TruffleHog OSS
-          uses: trufflesecurity/trufflehog@main
-          with:
-            path: ./
-            extra_args: --debug --only-verified
+jobs:
+  secrets-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          extra_args: --debug --only-verified


### PR DESCRIPTION
## Description
Fix TruffleHog GitHub Action failing on push-to-master by removing explicit base/head refs that resolve to the same commit

