### PR TITLE
fix: restore ANTLR shading and bump version to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.glue</groupId>
     <artifactId>dqdl</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 
     <properties>
         <antlr.generated.package>com.amazonaws.glue.ml.dataquality.dqdl</antlr.generated.package>
@@ -94,6 +94,13 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4</artifactId>
+            <version>${antlr.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
             <version>${antlr.version}</version>
         </dependency>
 
@@ -184,6 +191,10 @@
                             <pattern>com.amazonaws.glue.ml.dataquality.</pattern>
                             <shadedPattern>software.amazon.glue.</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>org.antlr.v4.runtime</pattern>
+                            <shadedPattern>software.amazon.glue.dqdl.shaded.org.antlr.v4.runtime</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>
@@ -196,6 +207,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>software.amazon.glue:*</include>
+                                    <include>org.antlr:antlr4-runtime</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
- Add antlr4-runtime as explicit dependency
- Set antlr4 scope to provided
- Shade org.antlr.v4.runtime into software.amazon.glue.dqdl.shaded
- Include org.antlr:antlr4-runtime in shade artifactSet
- Bump version from 1.0.6 to 1.0.7

This fixes the ANTLR runtime conflict with Spark (which bundles 4.9.3) by shading ANTLR 4.13.2 inside the dqdl jar.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
