### PR TITLE
ci: bump Shadow engine to v1.7 (canary)

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -1,5 +1,5 @@
 name: Shadow   # load-bearing: auto-approve.yml keys on this exact name
-# To upgrade the engine, bump the SHA in BOTH `uses:` and `shadow_ref` below
+# To upgrade the engine, bump the ref in BOTH `uses:` and `shadow_ref` below
 # (GitHub forbids expressions in `uses:`, so they can't share a variable).
 
 on:
@@ -40,11 +40,11 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.actor != 'github-actions[bot]' &&
        (github.event.issue.pull_request == null || github.event_name == 'pull_request_target'))
-    uses: sudsali/shadow/.github/workflows/shadow-review.yml@54ec94e0ca8c90d9b58ff95a2a06b175a115784e
+    uses: sudsali/shadow/.github/workflows/shadow-review.yml@v1.7
     with:
       pr_number: ${{ inputs.issue_number }}
       dry_run: ${{ inputs.dry_run && 'true' || 'false' }}
-      shadow_ref: 54ec94e0ca8c90d9b58ff95a2a06b175a115784e
+      shadow_ref: v1.7
       aws_region: us-east-1
       prompt_sm_prefix: dqdl-bot
     secrets:


### PR DESCRIPTION
## Summary

Canary re-pin of the Shadow PR-review engine from `54ec94e` (v1.6) to **v1.7**.

v1.7 adds two engine features (configurable `allowed_labels`, `bot.name`-branded rate-limit label). This PR makes **no `.shadow.yml` changes**, so those features stay dormant — it's purely a canary to validate the v1.7 engine runs end-to-end on a live repo before python-deequ and deequ re-pin.

## Changes

- `.github/workflows/issue-bot.yml` — bump `uses:` and `shadow_ref` from the `54ec94e` SHA to the `v1.7` tag (both must move together; GitHub forbids expressions in `uses:`).

## Safety

- **OIDC unaffected:** `GitHubActionsDQDLBot`'s trust is scoped to `repo:awslabs/dqdl:*`, not pinned to a workflow ref, so the engine-ref change doesn't affect role assumption.
- **Rollback:** revert to re-pin `54ec94e`.
- Validated by a `dry_run` dispatch on a live PR (results in a comment below).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
