### PR TITLE
ci: pin Shadow v1.7 by commit SHA, not the mutable tag

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -40,11 +40,11 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.actor != 'github-actions[bot]' &&
        (github.event.issue.pull_request == null || github.event_name == 'pull_request_target'))
-    uses: sudsali/shadow/.github/workflows/shadow-review.yml@v1.7
+    uses: sudsali/shadow/.github/workflows/shadow-review.yml@ed31ed7e30ef81be82d7b8b756b626f876036d73 # v1.7
     with:
       pr_number: ${{ inputs.issue_number }}
       dry_run: ${{ inputs.dry_run && 'true' || 'false' }}
-      shadow_ref: v1.7
+      shadow_ref: ed31ed7e30ef81be82d7b8b756b626f876036d73 # v1.7
       aws_region: us-east-1
       prompt_sm_prefix: dqdl-bot
     secrets:


### PR DESCRIPTION
## What

Pins the Shadow reusable-workflow ref in `.github/workflows/issue-bot.yml` to the full commit SHA that `v1.7` points to (`ed31ed7`), keeping a `# v1.7` comment for readability, instead of the mutable `v1.7` tag.

Both `uses:` and `shadow_ref:` move together (GitHub forbids expressions in `uses:`, so they can't share a variable).

## Why

The v1.7 re-pin (#41) landed as a mutable tag. Per GitHub's Actions supply-chain hardening guidance, a mutable tag can be repointed upstream — if that happened, untrusted code would run with this workflow's OIDC/secret access. Pinning the immutable SHA removes that risk while keeping the version human-readable via the comment.

No behavior change: `ed31ed7` is exactly what `v1.7` resolves to today.

## Consistency

Matches the SHA-pin already applied on deequ #759 and python-deequ #284, so all three repos pin the engine by immutable SHA.