### PR TITLE
ci: gate auto-approve behind SHADOW_AUTO_APPROVE (off by default)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   approve:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target'
+    # Opt-in: a bot approval can satisfy branch protection's required review,
+    # so auto-approval only runs where a maintainer sets SHADOW_AUTO_APPROVE=true.
+    if: vars.SHADOW_AUTO_APPROVE == 'true' && (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target')
     timeout-minutes: 2
 
     steps:


### PR DESCRIPTION
## What
Gates the auto-approve workflow behind a new repo/org variable **SHADOW_AUTO_APPROVE**, defaulting to **off**. Auto-approval now runs only where a maintainer has explicitly set SHADOW_AUTO_APPROVE=true.

## Why
An AppSec review of the Shadow bot flagged that the bot's APPROVE review can satisfy branch protection's required approving review (all repos require 1, bot not excluded). That means a PR whose findings were suppressed — e.g. via prompt injection in the diff — could be auto-approved and satisfy the human-review gate.

Making auto-approval opt-in (off by default) keeps a human approval on the critical path unless a maintainer deliberately enables it. The bot is comment-only in the default configuration.

## Change
One line: the `approve` job `if:` now additionally requires `vars.SHADOW_AUTO_APPROVE == 'true'`. The existing event guard (pull_request / pull_request_target) is preserved. No engine change.

## Note
Touches `.github/`, so per the auto-approve Condition-0 guard this PR itself requires human approval + merge.